### PR TITLE
Add current page pagination data to grid card templates.

### DIFF
--- a/templates/components/category/product-listing.html
+++ b/templates/components/category/product-listing.html
@@ -6,9 +6,9 @@
     <div {{#if settings.data_tag_enabled}} data-list-name="Category: {{category.name}}" {{/if}}>
         {{#if theme_settings.product_list_display_mode '===' 'grid'}}
             {{#if settings.data_tag_enabled}}
-                {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings event="list" }}
+                {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings current_page=pagination.category.current event="list" }}
             {{else}}
-                {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings}}
+                {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings current_page=pagination.category.current}}
             {{/if}}
         {{else}}
             {{#if settings.data_tag_enabled}}

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,6 +1,7 @@
 <article
     class="card
     {{#if alternate}} card--alternate{{/if}}"
+    data-current-page="{{current_page}}"
     data-test="card-{{id}}"
     {{#if settings.data_tag_enabled}}
         data-event-type="{{event}}"

--- a/templates/components/products/grid.html
+++ b/templates/components/products/grid.html
@@ -1,7 +1,7 @@
 <ul class="productGrid">
     {{#each products}}
     <li class="product">
-            {{>components/products/card settings=../settings show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
+            {{>components/products/card settings=../settings show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1) current_page=../current_page}}
     </li>
     {{/each}}
 </ul>

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -3,6 +3,7 @@ category:
     shop_by_price: true
     products:
         limit: {{theme_settings.categorypage_products_per_page}}
+cart: true
 ---
 {{inject "categoryProductsPerPage" theme_settings.categorypage_products_per_page}}
 {{#partial "head"}}


### PR DESCRIPTION
This pull request adds a pagination index for category pages to product card templates for grid layouts... I suspect the assignment of the `current_page` template parameter might need updating for other contexts that the grid.html template gets used. YMMV
