### PR TITLE
WIP demo to provide shoppers with a choice of free gifts using a proxy product and FREEGIFT coupon promotion

### DIFF
--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -290,39 +290,47 @@ export default class Cart extends PageManager {
         const $couponContainer = $('.coupon-code');
         const $couponForm = $('.coupon-form');
         const $codeInput = $('[name="couponcode"]', $couponForm);
-
+    
         $('.coupon-code-add').on('click', event => {
             event.preventDefault();
-
+    
             $(event.currentTarget).hide();
             $couponContainer.show();
             $couponContainer.attr('aria-hidden', false);
             $('.coupon-code-cancel').show();
             $codeInput.trigger('focus');
         });
-
+    
         $('.coupon-code-cancel').on('click', event => {
             event.preventDefault();
-
+    
             $couponContainer.hide();
             $couponContainer.attr('aria-hidden', true);
             $('.coupon-code-cancel').hide();
             $('.coupon-code-add').show();
         });
-
+    
         $couponForm.on('submit', event => {
             const code = $codeInput.val();
-
+    
             event.preventDefault();
-
+    
             // Empty code
             if (!code) {
                 return showAlertModal($codeInput.data('error'));
             }
-
+    
             utils.api.cart.applyCode(code, (err, response) => {
                 if (response.data.status === 'success') {
-                    this.refreshContent();
+                    // Show a success message
+                    showAlertModal('Coupon code applied successfully!', {
+                        icon: 'success',
+                        showCancelButton: false,
+                        onConfirm: () => {
+                            // Reload the window after the user clicks OK
+                            window.location.reload();
+                        },
+                    });
                 } else {
                     showAlertModal(response.data.errors.join('\n'));
                 }

--- a/config.json
+++ b/config.json
@@ -43,6 +43,23 @@
     "Firefox ESR"
   ],
   "settings": {
+      "store_locales": [
+      {
+        "lang": "en",
+        "channel_id": 1,
+        "store_hash": "foobar"
+      },
+      {
+        "lang": "es",
+        "channel_id": 1,
+        "store_hash": "foobar"
+      },
+      {
+        "lang": "fr",
+        "channel_id": 1,
+        "store_hash": "foobar"
+      }
+    ],
     "channels": [
       {
         "id": 1,

--- a/config.json
+++ b/config.json
@@ -46,18 +46,18 @@
       "store_locales": [
       {
         "lang": "en",
-        "channel_id": 1,
-        "store_hash": "foobar"
+        "channel_id": 4142422,
+        "store_hash": "abc123"
       },
       {
         "lang": "es",
-        "channel_id": 1,
-        "store_hash": "foobar"
+        "channel_id": 1274724,
+        "store_hash": "def123"
       },
       {
         "lang": "fr",
         "channel_id": 1,
-        "store_hash": "foobar"
+        "store_hash": "xyz123"
       }
     ],
     "channels": [

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -4,6 +4,44 @@ cart: true
 {{inject 'cancelButtonText' (lang 'common.cancel')}}
 {{#partial "page"}}
 {{inject 'invalidEntryMessage' (lang 'cart.invalid_entry_message')}}
+
+{{assignVar 'hasFreeGiftProxy' 0}}
+{{assignVar 'freeGiftOptions' 0}}
+{{assignVar 'hasFreeGift' 0}}
+{{#each cart.items}}
+  {{#if this.sku '===' 'GIFT-PROXY'}}
+    {{assignVar 'hasFreeGiftProxy' 1}}
+    {{#filter this.custom_fields "Gift options" property="name"}}
+      {{assignVar 'freeGiftOptions' this.value}}
+    {{/filter}}
+  {{/if}}
+{{/each}}
+{{#if (getVar 'hasFreeGiftProxy') '===' 1}}
+  {{#each cart.items}}
+    {{#inArray (split (getVar 'freeGiftOptions') ',') this.sku}}
+      {{assignVar 'hasFreeGift' 1}}
+    {{/inArray}}
+  {{/each}}
+{{/if}}
+<pre>
+hasFreeGiftProxy: {{getVar 'hasFreeGiftProxy'}}
+freeGiftOptions: {{getVar 'freeGiftOptions'}}
+hasFreeGift: {{getVar 'hasFreeGift'}}
+
+// IF hasFreeGiftProxy is true AND hasFreeGift is false then prompt customer to choose free gifts.
+// Add to cart URLs, e.g. `cart.php?action=add&sku=xlredtshirt`
+</pre>
+
+{{#and (if (getVar 'hasFreeGiftProxy')) (unless (getVar 'hasFreeGift'))}}
+<p>
+  <ul>
+    {{#each (split (getVar 'freeGiftOptions' ','))}}
+      <li><a href="{{settings.secure_base_url}}/cart.php?action=add&sku={{this}}">Add free gift {{this}}</a></li>
+    {{/each}}
+  </ul>
+</p>
+{{/and}}
+
 <div class="page">
 
     <div class="page-content" data-cart>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -26,6 +26,26 @@ blog:
     {{/each}}
 
 <div class="main full">
+    <h3>locale_name</h3>
+    <code>
+      {{{json locale_name}}}
+    </code>
+    <h3>theme_settings.store_locales</h3>
+    <code>
+      {{{json theme_settings.store_locales}}}
+    </code>
+    <h3>#each theme_settings.store_locales</h3>
+    <ul>
+      {{#each theme_settings.store_locales}}
+        <li>
+          <pre>
+            lang: {{this.lang}}
+            channel_id: {{this.channel_id}}
+            store_hash: {{this.store_hash}}
+          </pre>
+        </li>
+      {{/each}}
+    </ul>
     {{#if products.featured}}
         {{> components/products/featured products=products.featured columns=theme_settings.homepage_featured_products_column_count}}
     {{/if}}

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -32,7 +32,7 @@ blog:
     </code>
     <h3>theme_settings.store_locales</h3>
     <code>
-      {{{json theme_settings.store_locales}}}
+      {{{json theme_settings.store_locales}}}`
     </code>
     <h3>#each theme_settings.store_locales</h3>
     <ul>


### PR DESCRIPTION
- Coupon promotion `FREEGIFT` adds a proxy product to the cart
- Proxy product contains a custom field called "Gift options" with the SKUs for possible gift selections.
- Gift option SKUs have also been discounted 100% in the `FREEGIFT` coupon promotion
- Stencil template code detects if the proxy is present (and if gift options are NOT present in cart)
- Cart page UI is updated with gift option choices

Not working currently:
- When the `FREEGIFT` coupon is removed, the proxy product is automatically removed from cart but the gift option is not. There needs to be either a cleanup operation when a coupon is removed or some Stencil code to detect that a gift option is in the cart without the corresponding discount. 